### PR TITLE
Go 1.25.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,8 @@ jobs:
     strategy:
       matrix:
         goos: [windows, linux, darwin]
-        goarch: [amd64, 386, arm64]
-        buildtarget: ['go1.24.5']
-        exclude:
-          -
-            goos: darwin
-            goarch: 386
+        goarch: [amd64, arm64]
+        buildtarget: ['go1.25.0']
       fail-fast: false
     env:
       GOOS: ${{ matrix.goos }}
@@ -46,15 +42,14 @@ jobs:
           repository: 'golang/go'
           ref: ${{ matrix.buildtarget }}
 
-      # Patches for Go 1.24.x before more minor changes introduces.
+      # Patches for Go 1.25.x before more minor changes introduces.
       - name: Apply patch
         run: |
-          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/raw/refs/heads/build/unified-1-24-patch.diff | patch --verbose -p 1
-        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/f429f15f6305e4432afd7309b317e903bd76a5c0.diff | patch --verbose -p 1
-        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/41f545de980e9285b68ece40d4b4e63feef9c5a1.diff | patch --verbose -p 1
-        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/b6c99a977f732ee5553ddc75ae0fe3b47927fc1c.diff | patch --verbose -p 1
-        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/36d7775e030192d3bf2dc111d1f6cfa89eae5f0c.diff | patch --verbose -p 1
-        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/a3e4d4735a5d89f60b907308b556c5a53614914d.diff | patch --verbose -p 1
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/raw/refs/heads/build/unified-1-25-patch.diff | patch --verbose -p 1
+        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/830f1acfc984be44520621b001096845ebf40c7a.diff | patch --verbose -p 1
+        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/b5e4a6d5b3d0b076414d04cc3d6002f816bc0c25.diff | patch --verbose -p 1
+        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/949393bde276adbeaf41688f086feb23e24abe88.diff | patch --verbose -p 1
+        # curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://github.com/XTLS/go-win7/commit/fc29c4ae1cd53d6761d4324c4625cc8a149c55d3.diff | patch --verbose -p 1
 
       - name: Set-up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test-go1_22.yml
+++ b/.github/workflows/test-go1_22.yml
@@ -3,7 +3,7 @@ name: Build patched Go 1.22 for tests
 on:
   workflow_dispatch:
   #schedule:
-    #- cron: '0 0 * * 4,6'
+    #- cron: '0 0 * * 6'
   push:
     branches:
       - build

--- a/.github/workflows/test-go1_23.yml
+++ b/.github/workflows/test-go1_23.yml
@@ -2,8 +2,8 @@ name: Build patched Go 1.23 for tests
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '10 0 * * 4,6'
+  #schedule:
+    #- cron: '0 0 * * 4,6'
   push:
     branches:
       - build

--- a/.github/workflows/test-go1_23.yml
+++ b/.github/workflows/test-go1_23.yml
@@ -3,7 +3,7 @@ name: Build patched Go 1.23 for tests
 on:
   workflow_dispatch:
   #schedule:
-    #- cron: '0 0 * * 4,6'
+    #- cron: '0 0 * * 6'
   push:
     branches:
       - build

--- a/.github/workflows/test-go1_24.yml
+++ b/.github/workflows/test-go1_24.yml
@@ -3,7 +3,7 @@ name: Build patched Go 1.24 for tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '10 0 * * 4,6'
+    - cron: '10 0 * * 6'
   push:
     branches:
       - build

--- a/.github/workflows/test-go1_24.yml
+++ b/.github/workflows/test-go1_24.yml
@@ -3,7 +3,7 @@ name: Build patched Go 1.24 for tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '20 0 * * 4,6'
+    - cron: '10 0 * * 4,6'
   push:
     branches:
       - build

--- a/.github/workflows/test-go1_25.yml
+++ b/.github/workflows/test-go1_25.yml
@@ -3,7 +3,7 @@ name: Build patched Go 1.25 for tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '20 0 * * 4,6'
+    - cron: '20 0 * * 6'
   push:
     branches:
       - build

--- a/.github/workflows/test-go1_25.yml
+++ b/.github/workflows/test-go1_25.yml
@@ -3,7 +3,7 @@ name: Build patched Go 1.25 for tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 0 * * 4,6'
+    - cron: '20 0 * * 4,6'
   push:
     branches:
       - build
@@ -60,7 +60,7 @@ jobs:
       - name: Set-up Go
         uses: actions/setup-go@v5
         with:
-          #go-version-file: 'src/go.mod'
+          go-version-file: 'src/go.mod'
           check-latest: true
 
       - name: Build patched Go


### PR DESCRIPTION
Adjustments for building a patched Go 1.25 is almost ready.

Changes include:
- Adapt patches for Go 1.25
- Switching release system from Go 1.24 to Go 1.25
- Remove pre-compiled SDK for i386/i686/x86 (`GOARCH=386`) architecture
  - For x86-64/amd64 (`GOARCH=amd64`) and arm64/armv8 (`GOARCH=arm64`) architecture, pre-compiled SDK will be delivered as usual
  - This won't break the ability of cross-compiling to 32 bit i386/i686/x86 architecture
- Regular building test will also lowering the frequency from 2 times a week to 1 time a week